### PR TITLE
WIP: Random notes from a 'best practices' perspective

### DIFF
--- a/plugin/gcpsample_asset_manager/GCPSampleAssetManagerInterface.py
+++ b/plugin/gcpsample_asset_manager/GCPSampleAssetManagerInterface.py
@@ -67,18 +67,13 @@ class GCPSampleAssetManagerInterface(ManagerInterface):
             )
         
         # initialize a client for Google Cloud Spanner
-        print("Initializing Google Cloud Spanner for our OAIO plugin")
+        hostSession.logger().debug("Initializing Google Cloud Spanner for our OAIO plugin")
         
-        # GF: Get our config values
-        with open('config.toml', 'r') as f:
-            # Read the file contents
-            config = toml.load(f)
-
         # Your Cloud Spanner instance ID.
-        instance_id = config['cloud-spanner']['instance-id']
+        instance_id = managerSettings.get('cloud-spanner-instance-id')
 
         # Your Cloud Spanner database ID.
-        database_id = config['cloud-spanner']['database-id']
+        database_id = managerSettings.get('cloud-spanner-database-id')
 
         spanner_client = spanner.Client()
         instance = spanner_client.instance(instance_id)

--- a/plugin/gcpsample_asset_manager/GCPSampleAssetManagerInterface.py
+++ b/plugin/gcpsample_asset_manager/GCPSampleAssetManagerInterface.py
@@ -112,10 +112,6 @@ class GCPSampleAssetManagerInterface(ManagerInterface):
             # as well as the traits we are able to supply data for. It's
             # important to get this right, for more info, see:
             # https://openassetio.github.io/OpenAssetIO/classopenassetio_1_1v1_1_1host_api_1_1_manager.html#acdf7d0c3cef98cce7abaf8fb5f004354
-            if context.isForWrite() and ResolvesFutureEntitiesTrait.kId in traitSet:
-                ManagedTrait.imbueTo(policy)
-                ResolvesFutureEntitiesTrait.imbueTo(policy)
-
             if context.isForRead() and LocatableContentTrait.kId in traitSet:
                 ManagedTrait.imbueTo(policy)
                 LocatableContentTrait.imbueTo(policy)

--- a/src/gcpsample_client/manager_initialize.py
+++ b/src/gcpsample_client/manager_initialize.py
@@ -40,9 +40,7 @@ host_interface = GCPSampleHost()
 # manager = managerFactory.createManager('google.manager.gcpsample_asset_manager')
 
 # GF: We're going to externalize which manager we want to use in a toml file and just call this one method once
-manager = ManagerFactory.defaultManagerForInterface("manager.toml", host_interface, factory_impl, logger)
-# GF: Still to verify but I think we don't have to bother calling "initialize" when called this way
-# GF: TODO: Test if we can use settings in the .toml and whether they come through during the initialize
+manager = ManagerFactory.defaultManagerForInterface(host_interface, factory_impl, logger)
 
 print("Yay, it worked")
 # We now have an instance of the requested manager, but it is not

--- a/src/gcpsample_client/publishing.py
+++ b/src/gcpsample_client/publishing.py
@@ -42,21 +42,6 @@ if not ManagedTrait.isImbuedTo(policy):
 video_spec = DigitalVideoSpecification.create()
 video_spec.displayNameTrait().setName("Ginos Home Video")
 # NOTE: It is critical to always use the working_ref from now on.
-working_ref = manager.preflight(entity_ref, video_spec, context)
-
-# We then check if the manager can tell us where to save the file.
-if ResolvesFutureEntitiesTrait.isImbuedTo(policy):
-    working_data = manager.resolve(
-            working_ref, DigitalVideoSpecification.kTraitSet, context)
-    working_spec = DigitalVideoSpecification(working_data)
-    # GF: just print the display name
-    print(f"This video is called: {working_spec.displayNameTrait().getName}")
-
-    # GF: this is the old code for files, not needed for now
-    # if save_url := working_spec.locatableContentTrait().getLocation():
-    #     save_path = pathFromURL(save_url)  # URL decode etc
-    # if custom_encoding := working_spec.textEncodingTrait().getEncoding():
-    #     encoding = custom_encoding
 
 # Now we can write the file
 # GF: now we need to "do" the publish of the DigitalVideo
@@ -75,8 +60,7 @@ print("We are now publishing the Digital Video")
 # Now the data has been written, we register the file and the publish
 # is complete. Update the context retention to denote that we're going
 # to save a reference to this entity in our user's history.
-context.retention = context.kPermanent
-final_ref = manager.register(working_ref, video_spec.traitsData(), context)
+final_ref = manager.register(entity_ref, video_spec.traitsData(), context)
 
 # GF: instead lets just print to the console
 print(f"The final reference is: {final_ref}")

--- a/src/gcpsample_client/resolve.py
+++ b/src/gcpsample_client/resolve.py
@@ -21,10 +21,6 @@ context = manager.createContext()
 # We describe what we want to do with the asset
 context.access = context.access.kRead
 
-# We describe the lifetime of the returned reference
-# as persistent retention may require a more stable value.
-context.retention = context.retention.kTransient
-
 # We can now resolve a token we may have if it is a reference. In
 # this example, we'll attempt to resolve the LocatableContent trait
 # for the entity.

--- a/traits.yml
+++ b/traits.yml
@@ -40,39 +40,25 @@ traits:
           colorspace:
             type: string
             description: A valid OCIO color space name
-  video:
-    description: >
-      Traits that describe 3D moving pictures visual content such as digital and film based video assets
+  time:
+    description: Traits that define timporal qualities
     members:
-      Video:
-        description: A base trait for all 3D moving pictures
-        usage:
-          - entity
-      Digital:
-        description: Visual content defined by 3D moving pictures
-        usage:
-          - entity
-        properties:
-          width:
-            type: integer
-            description: The width of the video
-          height:
-            type: integer
-            description: The height of the video
-          pixelAspectRatio:
-            type: float
-            description: >
-              The aspect ratio of the video. Expressed as width/height.
-      OCIOColorManaged:
+      FrameRanged:
         description: >
-          Details of the color space of the video, when used in an
-          OpenColorIO managed pipeline.
+          The image is animated over time such as a video or image
+          sequence. Time is parameterized using a frame range.
         usage:
           - entity
         properties:
-          colorspace:
-            type: string
-            description: A valid OCIO color space name
+          startFame:
+            type: integer
+            description: The number of the first frame
+          endFame:
+            type: integer
+            description: The number of the last frame
+          frameRate:
+            type: float
+            description: The number of frames to play per second
 
 specifications:
   image:
@@ -96,26 +82,23 @@ specifications:
           - package: openassetio-mediacreation
             namespace: identity
             name: DisplayName
-          - package: openassetio-mediacreation
-            namespace: managementPolicy
-            name: Managed
-          - package: openassetio-mediacreation
-            namespace: managementPolicy
-            name: ResolvesFutureEntities
   video:
     description: Specifications for commonly encountered video types.
     members:
       DigitalVideo:
         description: >
-          3D moving pictures visual content from digital source content and stored in an external BLOB
+          3D moving pictures visual content from digital source content
+          and stored in an external BLOB
         usage:
           - entity
         traitSet:
-          - namespace: video
-            name: Video
-          - namespace: video
-            name: Digital
-          - namespace: video
+          - namespace: image
+            name: Image
+          - namespace: image
+            name: Raster
+          - namespace: time
+            name: FrameRanged
+          - namespace: image
             name: OCIOColorManaged
           - package: openassetio-mediacreation
             namespace: content
@@ -123,9 +106,3 @@ specifications:
           - package: openassetio-mediacreation
             namespace: identity
             name: DisplayName
-          - package: openassetio-mediacreation
-            namespace: managementPolicy
-            name: Managed
-          - package: openassetio-mediacreation
-            namespace: managementPolicy
-            name: ResolvesFutureEntities


### PR DESCRIPTION
Tweaked the specifications so the re-use as many traits as possible. This simplifies the mapping to well known existing data, and maximizes interoperability.

Sorry haven't had time to test this properly yet, but hope it illustrates the idea of re-using traits across specifications to simplify implementation on either side of the API. Please take it all with a pinch of salt, but this is the direction we're likely to go in in Media Creation itself.

Updated to include few notes on the host/manager side of things too.